### PR TITLE
Build .pocket ROM (and migrate to GBDK-4.0.5)

### DIFF
--- a/build.ninja
+++ b/build.ninja
@@ -15,15 +15,15 @@ rule bin2c
 
 rule cc
   depfile = $depfile
-  command = ../gbdk/bin/lcc -Wf-MD -Wa-l $in -c -o $out
+  command = ../gbdk/bin/lcc -mgbz80:ap -Wf-MD -Wa-l $in -c -o $out
   description = lcc $out
 
 rule asm
-  command = ../gbdk/bin/lcc -Wa-l $in -c -o $out
+  command = ../gbdk/bin/lcc -mgbz80:ap -Wa-l $in -c -o $out
   description = lcc $out
 
 rule link
-  command = ../gbdk/bin/lcc -Wl-j -Wl-m -Wl-w -Wl-yo4 -Wl-yt1 -Wm-ynPORKLIKE -Wm-yS -Wl-b_CALIGNED=0x0200 -Wl-b_CODE=0x300 -Wl-b_DALIGNED=0xc100 -Wl-b_DATA=0xcf00 $in -o $out
+  command = ../gbdk/bin/lcc -mgbz80:ap -Wl-j -Wl-m -Wl-w -Wl-yo4 -Wl-yt1 -Wm-ynPORKLIKE -Wm-yS -Wl-b_CALIGNED=0x0200 -Wl-b_CODE=0x300 -Wl-b_DALIGNED=0xc100 -Wl-b_DATA=0xcf00 $in -o $out
   description = link $out
 
 build out/bg.bin: rgbgfx bg.png
@@ -66,4 +66,4 @@ build out/sound.o: cc sound.c
 build out/main.o: cc main.c | out/tilebg.h out/tileshared.h out/tilesprites.h out/tiledead.h
   depfile = out/main.d
 
-build porklike.gb: link out/bank0.o out/aligned.o out/main.o out/sound.o out/util.o out/music.o out/title.o out/tiletitle.c out/tilebg.c out/tileshared.c out/tilesprites.c out/tiledead.c out/gen.o
+build porklike.pocket: link out/bank0.o out/aligned.o out/main.o out/sound.o out/util.o out/music.o out/title.o out/tiletitle.c out/tilebg.c out/tileshared.c out/tilesprites.c out/tiledead.c out/gen.o

--- a/main.c
+++ b/main.c
@@ -373,7 +373,7 @@ void main(void) NONBANKED {
 
   // Initialize for gameplay
   init_win(0);
-  LCDC_REG = 0b11100011;  // display on, window/bg/obj on, window@9c00
+  LCDC_REG = (LCDCF_ON | LCDCF_WINON | LCDCF_BGON | LCDCF_OBJON | LCDCF_WIN9C00); // display on, window/bg/obj on, window@9c00  
   gb_decompress_bkg_data(0x80, shared_bin);
   gb_decompress_sprite_data(0, sprites_bin);
   add_VBL(vbl_interrupt);

--- a/title.c
+++ b/title.c
@@ -100,7 +100,7 @@ void titlescreen(void) {
   gb_decompress_bkg_data(0x80, title_bin);
 
   init_bkg(0x8e);
-  LCDC_REG = 0b10000011;  // display on, bg/obj on,
+  LCDC_REG = (LCDCF_ON | LCDCF_BGON | LCDCF_OBJON); // display on, bg/obj on,
 
   // fade from white to black
   titlefadein();
@@ -148,7 +148,7 @@ void titlescreen(void) {
 
   WX_REG = 16 + 7;
   WY_REG = 160;
-  LCDC_REG = 0b11100011;  // display on, window/bg/obj on, window@9c00
+  LCDC_REG = (LCDCF_ON | LCDCF_WINON | LCDCF_BGON | LCDCF_OBJON | LCDCF_WIN9C00); // display on, window/bg/obj on, window@9c00
   init_win(0x8e);
   set_win_tiles(0, 0, TITLEBOT_WIDTH, TITLEBOT_HEIGHT, titlebot_map);
 

--- a/util.s
+++ b/util.s
@@ -1,8 +1,14 @@
+.include    "global.s"
+
 _clear_wram::
   ; TODO: no idea how to get the linker to calculate this for me...
   ld hl, #l__DALIGNED
-  ld de, #l__DATA
-  add hl, de
+  ; GBDK 4.0.5 now clears memory in __DATA assigned to vars
+  ; It expects vars populated before jump to main
+  ; (such int dispatch tables) to not get cleared
+  ;
+  ; ld de, #l__DATA
+  ; add hl, de
   push hl
   ld hl, #0
   push hl
@@ -288,8 +294,8 @@ _counter_out::
   ld l, a      ; hl = dest
 
 1$:
-  ldh a, (#0x41) ; wait until VRAM is unlocked
-  and a, #2
+  ldh a, (.STAT) ; wait until VRAM is unlocked
+  and a, #STATF_BUSY
   jr nz, 1$
 
   ld a, (de)    ; copy tile
@@ -316,8 +322,8 @@ _vram_copy::
   ld l, a  ; hl = dst
 
 1$:
-  ldh a, (#0x41) ; wait until VRAM is unlocked
-  and a, #2
+  ldh a, (.STAT) ; wait until VRAM is unlocked
+  and a, #STATF_BUSY
   jr nz, 1$
 
   ld a, (de)    ; copy tile


### PR DESCRIPTION
Consider this a rough draft PR:
- I don't understand ninja very well, but it seems like ninja may not be well suited to build both GB and AP targets without some duplication in the build file. So I just hardwired it to show what to change for building AP. (If both targets were to be supported, it might be good to build their intermediary files to separate directories to avoid having to clean between changing target platforms. There are some demo Makefiles that do this in the GBDK 4.0.5 multi-platform examples)
- The comment in util.s for _clear_wram could just be removed

Changes:
- Compat with GBDK 4.0.5 (crt0.s now clears vars allocated in _DATA and sets some vars in it, so only clear _DALIGNED)
- Change LCDC and STAT access to use constants that update based on target build platform
- Add lcc flags for .pocket target (-mgbz80:ap)

Tested and appears to work 